### PR TITLE
Add missing failure indicators for Huawei SmartAX

### DIFF
--- a/definitions/huawei_smartax.yaml
+++ b/definitions/huawei_smartax.yaml
@@ -43,7 +43,11 @@ failure_indicators:
   - '% Incomplete command'
   - '% Invalid input detected'
   - '% Unknown command'
+  - '% Too many parameters'
+  - '% Parameter error'
   - 'Error:'
+  - 'Failure:'
+  - 'The required ONT does not exist'
 on_open_instructions:
   - enter_mode:
       requested_mode: 'privileged_exec'


### PR DESCRIPTION
Adds the following failure indicators:

```console
OLT_NAME(config-if-gpon-0/1)#ont delete 1 29 
  Failure: The ONT does not exist

OLT_NAME(config)#display ont info by-sn 1111111111111119 
  The required ONT does not exist

OLT_NAME(config-if-gpon-0/1)#ont add 1 sn-auth 1111111111111119 omci ont-lineprofile-id 201 ont-srvprofile-id 201 desc "Example" 
  Failure: Invalid serial number

OLT_NAME#config test
                ^
  % Too many parameters, the error locates at '^'
  
OLT_NAME#display service-port 99999 
                              ^
  % Parameter error, the error locates at '^'
  ```

Fixes #8