### PR TITLE
Fix Huawei SmartAX privileged_exec prompt

### DIFF
--- a/definitions/huawei_smartax.yaml
+++ b/definitions/huawei_smartax.yaml
@@ -11,6 +11,8 @@ modes:
               input: 'enable'
   - name: 'privileged_exec'
     prompt_pattern: '^\S{1,48}#$'
+    prompt_excludes:
+      - '(config'
     accessible_modes:
       - name: 'exec'
         instructions:

--- a/definitions/huawei_smartax.yaml
+++ b/definitions/huawei_smartax.yaml
@@ -43,7 +43,11 @@ failure_indicators:
   - '% Incomplete command'
   - '% Invalid input detected'
   - '% Unknown command'
+  - '% Too many parameters'
+  - '% Parameter error'
   - 'Error:'
+  - 'Failure:'
+  - 'The required ONT does not exist'
 on_open_instructions:
   - enter_mode:
       requested_mode: 'privileged_exec'


### PR DESCRIPTION
The privileged_exec regex: `^\S{1,48}#$`, also matches `SCRAPLI_HUAWEI-SMARTAX_TEST_OLT1(config)#`. This causes a timeout when you are trying to go from configuration mode to privileged_exec mode because Scrapli thinks it's already in privileged_exec mode.